### PR TITLE
Fix IPython widget imports

### DIFF
--- a/examples/Examples.ipynb
+++ b/examples/Examples.ipynb
@@ -12,7 +12,7 @@
     "import numpy as np\n",
     "from IPython.display import display\n",
     "try:\n",
-    "    from jupyter_notebook.widgets import HTML, Text\n",
+    "    from IPython.html.widgets import HTML, Text\n",
     "    from traitlets import link, dlink\n",
     "except ImportError:\n",
     "    from IPython.html.widgets import HTML, Text\n",

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -9,10 +9,10 @@ Another resource to understanding three.js decisions is the Udacity course on 3d
 
 # Import the base Widget class and the traitlets Unicode class.
 try:
-    from jupyter_notebook.widgets.widget import Widget, DOMWidget, widget_serialization
+    from ipython_widgets import Widget, DOMWidget, widget_serialization
     from traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
                            Any, CFloat, Bool, This, CInt, TraitType)
-except ImportError: # IPython 3.x
+except ImportError:  # IPython 3.x
     from IPython.html.widgets.widget import Widget, DOMWidget, widget_serialization
     from IPython.utils.traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
                                          Any, CFloat, Bool, This, CInt, TraitType)


### PR DESCRIPTION
@jasongrout this fixes the imports for IPython 4.0dev.  With the second part of the Big Split, `jupyter_notebook.widgets` is gone and replaced with `ipython_widgets`
Besides, there is a shim for the old import path `IPython.html.widgets`.
